### PR TITLE
Rule tweaks 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ __Setup:__ For each player place 4 stones in the shape of a square in adjacent c
 
 __Life & Death:__ 2 hoplite are connected if they share an adjacent intersection. 2 or more connected hoplites are considered a living phalanx. A hoplite is dead if they are not connected to another hoplite, or if they are pushed off the board (more below). Dead hoplites are immediately removed from the board.
 
-__Flow of Play:__ Black takes the first turn, then players alternate back and forth. A turn consists of doing 0, 1 or 2 of the following actions (you may do the same action twice).
-- __MOVE:__ move up to 2 hoplites to an adjacent intersection touching their army. You may split or merge phalanx, but hoplites may not jump between unconnected phalanx.
+__Flow of Play:__ Black takes the first turn, then players alternate back and forth. A turn consists of doing optionally up to 3 actions. The same action may be done multiple times. The possible actions are:
+- __MOVE:__ move 1 hoplite to an adjacent intersection touching their army. You may split or merge phalanx, but hoplites may not jump between unconnected phalanx.
 - __RENFORCE/ADD:__ If you have less than 9 hoplites on the board, add a new hoplite to an existing phalanx
 - __PUSH:__ if your phalanx is connected to an opponent's, and the number of your hoplites is greater then the opponents in a straight line, and there is an open intersection on the other side of the line, you may slide the whole line towards the opponent's hoplites 1 intersection. Hoplites pushed off the board are dead.
 

--- a/src/lib/globals.fnl
+++ b/src/lib/globals.fnl
@@ -1,4 +1,5 @@
 (global globals {:map-size 9
+                 :moves-per-turn 3
                  :col {:BLACK "black"
                        :WHITE "white"}
                  :dir {:UP "up"

--- a/src/phalanx.fnl
+++ b/src/phalanx.fnl
@@ -25,13 +25,13 @@
     "the number of remain stones (max of 9) looking at the stone-map"
     (- 9 (lume.count (only color board))))
 
-(fn stone-at [x y board]
+(fn stone-at [pos board]
     "returns  (values stone board-index)"
-    (lume.match board (lambda [stone] (loc= stone {: x : y}))))
+    (lume.match board (lambda [stone] (loc= stone pos))))
 
-(fn color-at [x y board]
-    "the color at the coords"
-    (match (pick-values 1 (stone-at x y board))
+(fn color-at [pos board]
+    "the color at the pos"
+    (match (pick-values 1 (stone-at pos board))
            nil nil
            spot spot.color))
 
@@ -42,112 +42,115 @@
            col.BLACK col.WHITE
            _ nil))
 
-(fn in-bounds [coord]
-    (and (> coord.x 0)
-         (<= coord.x globals.map-size)
-         (> coord.y 0)
-         (<= coord.y globals.map-size)
-         (not (loc= coord {:x 1 :y 1})) ;; exclude black temple
-         (not (loc= coord {:x 9 :y 9})))) ;; exclude white temple
+(fn in-bounds [pos]
+    "are the xy poss inside the bounds of the board (temples are out of bounds)"
+    (and (> pos.x 0)
+         (<= pos.x globals.map-size)
+         (> pos.y 0)
+         (<= pos.y globals.map-size)
+         (not (loc= pos {:x 1 :y 1})) ;; exclude black temple
+         (not (loc= pos {:x 9 :y 9})))) ;; exclude white temple
 
-(fn find-neighbors [x y color board]
+(fn neighbors-of [pos board]
+    [{:x (+ pos.x 1) :y pos.y}
+     {:x (- pos.x 1) :y pos.y}
+     {:x pos.x :y (+ pos.y 1)}
+     {:x pos.x :y (- pos.y 1)}])
+
+(fn is-neighbor-of [pos-a pos-b board]
+    "check if pos-a is a neighbor of pos b"
+    (lume.any (neighbors-of pos-a board) #(loc= $1 pos-b)))
+
+(fn valid-neighbors [pos color board]
     "return the orthogonal neighbors which are the desired color. passing nil for color will find open neighbors"
-    (let [neighbors [{ :x (+ x 1) :y y}
-                     { :x (- x 1) :y y}
-                     { :x x :y (+ y 1)}
-                     { :x x :y (- y 1)}]]
-      (lume.filter neighbors
-                   (lambda [neighbor]
-                     (and (= color (color-at neighbor.x neighbor.y board))
-                          (in-bounds neighbor))))))
-
-(fn possible-adds [color board]
-    "possible locations for the add action for a color on a map.
-     [{event:'add' x:2 y:3}]"
-    (lume.reduce (only color board)
-                 (lambda [acc stone]
-                   (lume.each (find-neighbors stone.x stone.y nil board)
-                              (lambda [coords]
-                                (when (not (lume.any acc #(loc= $1 coords)))
-                                  (lume.push acc (lume.merge coords {:event "add"})))))
-                   acc)
-                 {}))
-
-(fn remove-stone [x y old-board]
-    "return a new board with a stone removed at given coords"
-    (lume.reject old-board (lambda [spot] (loc= spot {: x : y}))))
-
-(fn place-stone [x y color old-board]
-    "return a new board with a stone added given coords"
-    (let [new-board (lume.deepclone old-board)]
-      (table.insert new-board {: x : y : color})
-      (lume.unique new-board)))
-
-(fn possible-moves [color board]
-    "possible moves for the board, a move consists of 2 from->to locations
-     [{event:'move' moves: [{x:1 y:1 x2:2 y2:3}, {x:1 y:1 x2:2 y2:3}]}]"
-    (fn possible-moves-tail [color board]
-        (lume.reduce (only color board)
-                     (lambda [acc from]
-                       (lume.each (possible-adds color (remove-stone from.x from.y board))
-                                  (lambda [to]
-                                    (lume.push acc {:x from.x :y from.y
-                                                    :x2 to.x :y2 to.y})))
-                       acc)))
-    (var moves {})
-    (lume.each (possible-moves-tail color board)
-               (lambda [move1]
-                 (let [second-move-board (->> board
-                                              (remove-stone move1.x move1.y)
-                                              (place-stone move1.x2 move1.y2 color))]
-                   (lume.each (possible-moves-tail color second-move-board)
-                              (lambda [move2]
-                                (table.insert moves
-                                              {:event "move"
-                                               :moves [move1 move2]}))))))
-    moves)
+    (lume.filter (neighbors-of pos)
+                 #(and (= color (color-at $1 board)
+                        (in-bounds $1)))))
 
 (fn opposite [direction]
+    "the opposite orthogonal direction"
     (match direction
            dir.LEFT dir.RIGHT
            dir.RIGHT dir.LEFT
            dir.UP dir.DOWN
            dir.DOWN dir.UP))
 
-(fn direction-iters [direction]
+(fn direction-iter [direction]
+    "function to move a pos in a direction"
     (match direction
-           dir.LEFT (values #(- $1 1) #$1)
-           dir.RIGHT (values #(+ $1 1) #$1)
-           dir.UP (values #$1 #(- $1 1))
-           dir.DOWN (values #$1 #(+ $1 1))))
+           dir.LEFT  #(lume.merge $1 {:x (- (. $1 :x) 1)})
+           dir.RIGHT #(lume.merge $1 {:x (+ (. $1 :x) 1)})
+           dir.UP    #(lume.merge $1 {:y (- (. $1 :y) 1)})
+           dir.DOWN  #(lume.merge $1 {:y (+ (. $1 :y) 1)})))
 
+(fn remove-stone [x y old-board]
+    "return a new board with a stone removed at given poss"
+    (lume.reject old-board (lambda [spot] (loc= spot {: x : y}))))
 
-(fn get-starting-position [x y color direction board]
+(fn place-stone [x y color old-board]
+    "return a new board with a stone added given poss"
+    (let [new-board (lume.deepclone old-board)]
+      (table.insert new-board {: x : y : color})
+      (lume.unique new-board)))
+
+(fn place-stones [stones old-board]
+    (let [new-board (lume.deepclone old-board)]
+      (lume.each stones #(table.insert new-board $1))
+      (lume.unique new-board)))
+
+(fn remove-stones [stones old-board]
+    "return a new board with all the stones given removed"
+    (lume.unique (lume.reject old-board
+                              (lambda [pos] (lume.any stones #(loc= $1 pos))))))
+
+(fn get-starting-position [pos color direction board]
+    "the furthest stone away from opponate on the push line"
     (let [opponate-color (other color)
-                         (x-iter y-iter) (direction-iters (opposite direction))] ;; NOTE: we need to look backwords
-      (fn get-starting-position-tail [x y]
-          (match (color-at (x-iter x) (y-iter y) board)
-                 nil (values x y)
-                 opponate-color (values x y)
-                 color (get-starting-position-tail (x-iter x) (y-iter y))))
-      (get-starting-position-tail x y)))
+          iter (direction-iter (opposite direction))] ;; NOTE: we need to look backwords
+      (fn get-starting-position-tail [pos]
+          (match (color-at (iter pos) board)
+                 nil pos
+                 opponate-color pos
+                 color (get-starting-position-tail (iter pos))))
+      (get-starting-position-tail pos)))
 
-(fn is-possible-push [start-x start-y color direction board]
+(fn is-possible-push [starting-pos color direction board]
     "check if pushing a line starting from a point for a color in a direction is valid"
-    (let [(start-x start-y) (get-starting-position start-x start-y color direction board)
-          (x-iter y-iter) (direction-iters direction)
+    (let [starting-pos (get-starting-position starting-pos color direction board)
+          iter (direction-iter direction)
           opponate-color (other color)]
-      (fn is-possible-push-tail [x y ally-count opponate-count]
-          (match (color-at x y board)
+      (fn is-possible-push-tail [pos ally-count opponate-count]
+          (match (color-at pos board)
                  color (if (> opponate-count 0)
                            false ;; you've blocked yourself
-                           (is-possible-push-tail (x-iter x) (y-iter y) (+ 1 ally-count) opponate-count))
-                 opponate-color (is-possible-push-tail (x-iter x) (y-iter y) ally-count (+ 1 opponate-count))
+                           (is-possible-push-tail (iter pos) (+ 1 ally-count) opponate-count))
+                 opponate-color (is-possible-push-tail (iter pos) ally-count (+ 1 opponate-count))
                  nil (and (> opponate-count 0) ;; must actually touch opponate
                           (>  ally-count opponate-count))))  ;; must be longer then opponate
-      (if (= color (color-at start-x start-y board))
-          (is-possible-push-tail start-x start-y 0 0)
+      (if (= color (color-at starting-pos board))
+          (is-possible-push-tail starting-pos 0 0)
           false))) ;; must start on your own color
+
+(fn possible-adds [color board]
+    "possible locations for the add action for a color on a map.
+     [{event:'add' x:2 y:3}]"
+    (lume.reduce (only color board)
+                 (lambda [acc stone]
+                   (lume.each (valid-neighbors stone nil board)
+                              (lambda [poss]
+                                (when (not (lume.any acc #(loc= $1 poss)))
+                                  (lume.push acc (lume.merge poss {:event "add"})))))
+                   acc)
+                 {}))
+
+(fn possible-moves [color board]
+    "possible moves for the board, a move consists of 'from' and 'to' locations
+     [{event: 'move', from: {x y}, to: {x y}}]"
+    (lume.reduce (only color board)
+                 (lambda [acc from]
+                   (lume.each (possible-adds color (remove-stone from.x from.y board))
+                              (lambda [to] (lume.push acc {:event "move" : from : to})))
+                   acc)))
 
 (fn possible-pushes [color board]
     "list of all possible pushes for a color on the board
@@ -162,90 +165,67 @@
                                   (table.insert pushes (lume.extend stone {:direction direction :event "push"})))))))
       (lume.unique pushes)))
 
-(fn is-possible-add [x y color board]
-    "check if the x y coords and a color is a valid add move"
-    (lume.any (possible-adds color board) #(loc= $1 {: x : y})))
+(fn is-possible-add [pos color board]
+    "check if the pos and a color is a valid add move"
+    (lume.any (possible-adds color board) #(loc= $1 pos)))
 
-(fn army-at [x y color board]
+(fn army-at [pos color board]
     "find all connected pieces (an army) for a color starting at a position"
-    (fn army-tail [x y seen-stones]
-        (lume.each (find-neighbors x y color board)
+    (fn army-tail [pos seen-stones]
+        (lume.each (valid-neighbors pos color board)
                    (lambda [stone]
-                     (when (not (stone-at stone.x stone.y seen-stones))
-                       (table.insert seen-stones {:x stone.x :y stone.y :color color})
-                       (lume.concat seen-stones (army-tail stone.x stone.y seen-stones)))))
+                     (when (not (stone-at stone seen-stones))
+                       (table.insert seen-stones (lume.merge stone {: color}))
+                       (lume.concat seen-stones (army-tail stone seen-stones)))))
         seen-stones)
-    (army-tail x y []))
+    (army-tail pos []))
 
 
 (fn dead-stones [board]
     "list of all the dead/isolated stones on the board"
     (lume.filter board (lambda [stone]
-                         (or (= 0 (# (find-neighbors stone.x stone.y stone.color board)))
+                         (or (= 0 (# (valid-neighbors stone stone.color board)))
                              (not (in-bounds stone))))))
 
-(fn place-stones [stones old-board]
-    (let [new-board (lume.deepclone old-board)]
-      (lume.each stones #(table.insert new-board $1))
-      (lume.unique new-board)))
-
-(fn remove-stones [stones old-board]
-    "return a new board with all the stones given removed"
-    (lume.unique (lume.reject old-board
-                              (lambda [spot]
-                                (lume.any stones (lambda [dspot]
-                                                   (and (= dspot.x spot.x)
-                                                        (= dspot.y spot.y))))))))
-
-(fn push [x y color direction old-board]
-    "return a new board after a push action at the given coords and direction"
+(fn push [starting-pos color direction old-board]
+    "return a new board after a push action at the given pos and direction"
     (let [new-board (lume.deepclone old-board)
-                    (start-x start-y) (get-starting-position x y color direction new-board)
-                    (x-iter y-iter) (direction-iters direction)]
-      (fn push-line-tail [x y board]
-          (match (stone-at x y old-board)
+          start-pos (get-starting-position starting-pos color direction new-board)
+          iter (direction-iter direction)]
+      (fn push-line-tail [pos]
+          (match (stone-at pos old-board)
                  (next-stone index) (do
-                                     (tset new-board index {:x (x-iter x) :y (y-iter y) :color next-stone.color})
+                                     (tset new-board index (lume.merge pos {:color next-stone.color}))
                                      (when (~= nil next-stone.color)
-                                       (push-line-tail (x-iter x) (y-iter y) next-stone.color)))))
-      (push-line-tail start-x start-y)
+                                       (push-line-tail (iter pos) next-stone.color)))))
+      (push-line-tail starting-pos)
       (lume.unique new-board)))
 
-(fn undo-push [x y color direction old-board]
-    "return a new board after a push action at the given coords and direction has been undone. This requires some special attention/tweaks"
+(fn undo-push [starting-pos color direction old-board]
+    "return a new board after a push action at the given pos and direction has been undone. This requires some special attention/tweaks"
     (let [new-board (lume.deepclone old-board)
-                    (x-iter y-iter) (direction-iters direction)
-                    (start-x start-y) (get-starting-position (x-iter x) (y-iter y) color direction new-board)
-                    (opp-x-iter opp-y-iter) (direction-iters (opposite direction))]
-      (fn pushnt-line-tail [x y board]
-          (match (stone-at x y old-board)
+          iter (direction-iter direction)
+          starting-pos (get-starting-position (iter startin-pos) color direction new-board)
+          opp-iter (direction-iter (opposite direction))]
+      (fn pushnt-line-tail [pos board]
+          (match (stone-at pos old-board)
                  (next-stone index) (do
-                                     (tset new-board index {:x (opp-x-iter x) :y (opp-y-iter y) :color next-stone.color})
+                                     (tset new-board index (lume.merge (opp-iter pos) {:color next-stone.color}))
                                      (when (~= nil next-stone.color)
-                                       (pushnt-line-tail (x-iter x) (y-iter y) next-stone.color)))))
-      (pushnt-line-tail start-x start-y)
+                                       (pushnt-line-tail (iter pos) next-stone.color)))))
+      (pushnt-line-tail starting-pos)
       (lume.unique new-board)))
-
-
-(fn neighbor-of [x y x-goal y-goal]
-    "check if (x,y) is a neighbor of (x-goal, y-goal)"
-    (let [goal {:x x-goal :y y-goal}
-          neighbors [{ :x (+ x 1) :y y}
-                     { :x (- x 1) :y y}
-                     { :x x :y (+ y 1)}
-                     { :x x :y (- y 1)}]]
-      (lume.any neighbors #(loc= $1 goal))))
 
 (fn goal-position [color]
-    (values (if (= color col.BLACK) 1 9)
-            (if (= color col.BLACK) 1 9)))
+    (match color
+           col.BLACK {:x 1 :y 9}
+           col.WHITE {:x 1 :y 9}))
 
 (fn touching-temple [color board]
     "check if color is touching the temple"
-    (let [(x-goal y-goal) (goal-position color)]
-      (lume.any board (lambda [spot]
-                        (and (= spot.color color)
-                             (neighbor-of spot.x spot.y x-goal y-goal))))))
+    (lume.any board
+              #(and (= (. $1 :color) color)
+                    (is-neighbor-of $1 (goal-position color)))))
 
 (fn game-over [board]
     "return color that has won the game, else false"

--- a/src/phalanx.fnl
+++ b/src/phalanx.fnl
@@ -148,7 +148,7 @@
      [{event: 'move', from: {x y}, to: {x y}}]"
     (lume.reduce (only color board)
                  (lambda [acc from]
-                   (lume.each (possible-adds color (remove-stone from.x from.y board))
+                   (lume.each (possible-adds color (remove-stone from board))
                               (lambda [to] (lume.push acc {:event "move" : from : to})))
                    acc)))
 
@@ -161,7 +161,7 @@
                  (lambda [stone]
                    (lume.each [dir.LEFT dir.RIGHT dir.UP dir.DOWN]
                               (lambda [direction]
-                                (when (is-possible-push stone.x stone.y color direction board)
+                                (when (is-possible-push stone color direction board)
                                   (table.insert pushes (lume.extend stone {:direction direction :event "push"})))))))
       (lume.unique pushes)))
 
@@ -190,12 +190,13 @@
 (fn push [starting-pos color direction old-board]
     "return a new board after a push action at the given pos and direction"
     (let [new-board (lume.deepclone old-board)
-          start-pos (get-starting-position starting-pos color direction new-board)
+          starting-pos (get-starting-position starting-pos color direction new-board)
           iter (direction-iter direction)]
       (fn push-line-tail [pos]
+          "PS this mutates new-board"
           (match (stone-at pos old-board)
                  (next-stone index) (do
-                                     (tset new-board index (lume.merge pos {:color next-stone.color}))
+                                     (tset new-board index (lume.merge (iter pos) {:color next-stone.color}))
                                      (when (~= nil next-stone.color)
                                        (push-line-tail (iter pos) next-stone.color)))))
       (push-line-tail starting-pos)

--- a/src/phalanx.fnl
+++ b/src/phalanx.fnl
@@ -258,7 +258,7 @@
       (when (> (# dead-stones) 0) (self:clean dead-stones)))
     (when (= self.state.current-turn-action-counter 0)
       (tset self.state :current-turn (other self.state.current-turn))
-      (tset self.state :current-turn-action-counter 2)
+      (tset self.state :current-turn-action-counter globals.moves-per-turn)
       (self:clearHistory))
     (let [winner (game-over self.state.board)]
       (when winner (self:endgame winner))))
@@ -332,7 +332,7 @@
 
 (fn init-board [?board ?turn]
     (machine.create {:state {:army nil ;; used for limiting move actions
-                             :current-turn-action-counter 2
+                             :current-turn-action-counter globals.moves-per-turn
                              :current-turn (or ?turn col.BLACK)
                              :board (or ?board
                                         [{:x 2 :y 2 :color col.WHITE}

--- a/src/views/game.fnl
+++ b/src/views/game.fnl
@@ -15,7 +15,7 @@
 
 (var fsm nil)
 
-(var cursor {:action 2 :x 5 :y 5 :direction dir.UP})
+(var cursor {:action 2 :pos {:x 5 :y 5} :direction dir.UP})
 
 (fn init []
     (set fsm (phalanx.init-board)))
@@ -40,11 +40,11 @@
 
 (fn cursor-movement-handler [key event]
     (match key
-           dir.RIGHT (tset cursor :x (+ cursor.x 1))
-           dir.LEFT (tset cursor :x (- cursor.x 1))
-           dir.UP (tset cursor :y (- cursor.y 1))
-           dir.DOWN (tset cursor :y (+ cursor.y 1))
-           "x" (: fsm event cursor.x cursor.y cursor.direction)
+           dir.RIGHT (tset cursor.pos :x (+ cursor.pos.x 1))
+           dir.LEFT (tset cursor.pos :x (- cursor.pos.x 1))
+           dir.UP (tset cursor.pos :y (- cursor.pos.y 1))
+           dir.DOWN (tset cursor.pos :y (+ cursor.pos.y 1))
+           "x" (: fsm event cursor.pos cursor.direction)
            "b" (: fsm :undoTransition)))
 
 (fn direction-handler [key]
@@ -62,19 +62,13 @@
                                      dir.LEFT (tset cursor :action (- cursor.action 1))
                                      "x" (: fsm
                                             (match cursor.action 1 :add 2 :move 3 :lineup)
-                                            cursor.x cursor.y cursor.direction)
+                                            cursor.pos cursor.direction)
                                      "b" (: fsm :undoTransition))
-           ;; add action
            "placing-stone" (cursor-movement-handler key :place)
-           ;; move action
-           "picking-first-stone" (cursor-movement-handler key :pick)
-           "placing-first-stone" (cursor-movement-handler key :place)
-           "picking-second-stone" (cursor-movement-handler key :pick)
-           "placing-second-stone" (cursor-movement-handler key :place)
-           ;; push action
-           "picking-push-line" (do
-                                (cursor-movement-handler key :push)
-                                (direction-handler key))))
+           "picking-stone" (cursor-movement-handler key :pick)
+           "lining-up-push" (do
+                             (cursor-movement-handler key :push)
+                             (direction-handler key))))
     (match cursor
            {:action 0} (tset cursor :action 3)
            {:action 4} (tset cursor :action 1)
@@ -97,7 +91,7 @@
     (gfx.rect col.WHITE 170 170 20 20))
 
 (fn draw-cursor []
-    (gfx.circle fsm.state.current-turn (* cursor.x 20) (* cursor.y 20) 7))
+    (gfx.circle fsm.state.current-turn (* cursor.pos.x 20) (* cursor.pos.y 20) 7))
 
 (fn draw-ui []
     ;; (gfx.print (.. "White remaining: " (fsm.functs.free-stones-count col.WHITE))  200 10)
@@ -112,17 +106,11 @@
               (gfx.rect col.BLACK (- x 4) 69 39 20))))
     (match fsm.current
            "selecting-action" nil
-           ;; add action
            "placing-stone" (draw-cursor)
-           ;; move action
-           "picking-first-stone" (draw-cursor)
-           "placing-first-stone" (draw-cursor)
-           "picking-second-stone" (draw-cursor)
-           "placing-second-stone" (draw-cursor)
-           ;; push action
-           "picking-push-line" (do
-                                (draw-cursor)
-                                (gfx.print (.. "direction: " cursor.direction) 200 90))))
+           "picking-stone" (draw-cursor)
+           "lining-up-push" (do
+                             (draw-cursor)
+                             (gfx.print (.. "direction: " cursor.direction) 200 90))))
 
 (fn draw []
     (draw-board)

--- a/src/views/game.fnl
+++ b/src/views/game.fnl
@@ -27,16 +27,14 @@
           (match action.event
                  "add" (do
                         (fsm:add)
-                        (fsm:place action.x action.y))
+                        (fsm:place action))
                  "move" (do
                          (fsm:move)
-                         (lume.each action.moves
-                                   (lambda [move]
-                                     (fsm:pick move.x move.y)
-                                     (fsm:place move.x2 move.y2))))
+                         (fsm:pick action.from)
+                         (fsm:place action.to))
                  "push" (do
                          (fsm:lineup)
-                         (fsm:push action.x action.y action.direction)))))))
+                         (fsm:push action action.direction)))))))
 
 (fn cursor-movement-handler [key event]
     (match key


### PR DESCRIPTION
move action only moves 1 stone, but you now get 3 actions per turn. This greatly simplifies the logic for calculating possibles moves, make the move action, the FSM, and the AI all while not really changing the feel of the game  

also switches all functions to using the position object `{:x :y}` instead of having individual x y coords.. I hope this doesnt bit me in the future with the fact that lua passes tables by reference